### PR TITLE
added basic divider with orientation prop and readme

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -65,6 +65,9 @@ export namespace Components {
          */
         "value": string;
     }
+    interface FlDivider {
+        "orientation": "vertical" | "horizontal";
+    }
     interface FlInput {
         "accept": string;
         "alt": string;
@@ -185,6 +188,12 @@ declare global {
         prototype: HTMLFlCheckboxElement;
         new (): HTMLFlCheckboxElement;
     };
+    interface HTMLFlDividerElement extends Components.FlDivider, HTMLStencilElement {
+    }
+    var HTMLFlDividerElement: {
+        prototype: HTMLFlDividerElement;
+        new (): HTMLFlDividerElement;
+    };
     interface HTMLFlInputElement extends Components.FlInput, HTMLStencilElement {
     }
     var HTMLFlInputElement: {
@@ -219,6 +228,7 @@ declare global {
         "fl-badge": HTMLFlBadgeElement;
         "fl-button": HTMLFlButtonElement;
         "fl-checkbox": HTMLFlCheckboxElement;
+        "fl-divider": HTMLFlDividerElement;
         "fl-input": HTMLFlInputElement;
         "fl-item": HTMLFlItemElement;
         "fl-link": HTMLFlLinkElement;
@@ -283,6 +293,9 @@ declare namespace LocalJSX {
           * Value of checkbox
          */
         "value"?: string;
+    }
+    interface FlDivider {
+        "orientation"?: "vertical" | "horizontal";
     }
     interface FlInput {
         "accept"?: string;
@@ -392,6 +405,7 @@ declare namespace LocalJSX {
         "fl-badge": FlBadge;
         "fl-button": FlButton;
         "fl-checkbox": FlCheckbox;
+        "fl-divider": FlDivider;
         "fl-input": FlInput;
         "fl-item": FlItem;
         "fl-link": FlLink;
@@ -406,6 +420,7 @@ declare module "@stencil/core" {
             "fl-badge": LocalJSX.FlBadge & JSXBase.HTMLAttributes<HTMLFlBadgeElement>;
             "fl-button": LocalJSX.FlButton & JSXBase.HTMLAttributes<HTMLFlButtonElement>;
             "fl-checkbox": LocalJSX.FlCheckbox & JSXBase.HTMLAttributes<HTMLFlCheckboxElement>;
+            "fl-divider": LocalJSX.FlDivider & JSXBase.HTMLAttributes<HTMLFlDividerElement>;
             "fl-input": LocalJSX.FlInput & JSXBase.HTMLAttributes<HTMLFlInputElement>;
             "fl-item": LocalJSX.FlItem & JSXBase.HTMLAttributes<HTMLFlItemElement>;
             "fl-link": LocalJSX.FlLink & JSXBase.HTMLAttributes<HTMLFlLinkElement>;

--- a/packages/core/src/components/fl-divider/fl-divider.css
+++ b/packages/core/src/components/fl-divider/fl-divider.css
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+}
+
+.horizontal {
+  display: flex;
+  width: 150px;
+  height: 2px;
+  background-color: #DDDDDD;
+  position: inherit;
+  top: 0px;
+  left: 50px;
+}
+
+.vertical { 
+  margin: auto;
+  width: 2px;
+  height: 150px;
+  background-color: #DDDDDD;
+  position: inherit;
+  top: 0px;
+  left: 50px;
+}

--- a/packages/core/src/components/fl-divider/fl-divider.tsx
+++ b/packages/core/src/components/fl-divider/fl-divider.tsx
@@ -1,0 +1,20 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'fl-divider',
+  styleUrl: 'fl-divider.css',
+  shadow: true,
+})
+export class FlDivider {
+
+@Prop() orientation: "vertical" | "horizontal" = "horizontal";
+
+  render() {
+    return (
+      <Host>
+        <div class={this.orientation}/>
+      </Host>
+    );
+  }
+
+}

--- a/packages/core/src/components/fl-divider/readme.md
+++ b/packages/core/src/components/fl-divider/readme.md
@@ -1,0 +1,33 @@
+---
+title: divider
+---
+
+# fl-divider
+
+## Showcase
+
+<div style="width:160px;">
+<span>horizontal</span>
+<fl-divider></fl-divider>
+<span>divider</span>
+</div>
+
+<div style="width:160px;">
+<span>vertical</span>
+<fl-divider orientation="vertical"></fl-divider>
+<span>divider</span>
+</div>
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute     | Description | Type                         | Default        |
+| ------------- | ------------- | ----------- | ---------------------------- | -------------- |
+| `orientation` | `orientation` |             | `"horizontal" \| "vertical"` | `"horizontal"` |
+
+
+----------------------------------------------
+
+

--- a/packages/core/src/components/fl-divider/test/fl-divider.e2e.ts
+++ b/packages/core/src/components/fl-divider/test/fl-divider.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('fl-divider', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<fl-divider></fl-divider>');
+
+    const element = await page.find('fl-divider');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/core/src/components/fl-divider/test/fl-divider.spec.tsx
+++ b/packages/core/src/components/fl-divider/test/fl-divider.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { FlDivider } from '../fl-divider';
+
+describe('fl-divider', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [FlDivider],
+      html: `<fl-divider></fl-divider>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <fl-divider>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </fl-divider>
+    `);
+  });
+});

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -11,6 +11,7 @@ defineCustomElements();
 export const FlBadge = /*@__PURE__*/createReactComponent<JSX.FlBadge, HTMLFlBadgeElement>('fl-badge');
 export const FlButton = /*@__PURE__*/createReactComponent<JSX.FlButton, HTMLFlButtonElement>('fl-button');
 export const FlCheckbox = /*@__PURE__*/createReactComponent<JSX.FlCheckbox, HTMLFlCheckboxElement>('fl-checkbox');
+export const FlDivider = /*@__PURE__*/createReactComponent<JSX.FlDivider, HTMLFlDividerElement>('fl-divider');
 export const FlInput = /*@__PURE__*/createReactComponent<JSX.FlInput, HTMLFlInputElement>('fl-input');
 export const FlItem = /*@__PURE__*/createReactComponent<JSX.FlItem, HTMLFlItemElement>('fl-item');
 export const FlLink = /*@__PURE__*/createReactComponent<JSX.FlLink, HTMLFlLinkElement>('fl-link');


### PR DESCRIPTION
Tracking issue: #14  

## Summary
This PR introduces the fl-divider tag. It currently possesses a single prop for orientation.

## Tests

Noteworthy cases:
Check out the readme file for examples of using the divider component.

## Documentation
# fl-spinner

<!-- Auto Generated Below -->

## Properties

| Property      | Attribute     | Description | Type                         | Default        |
| ------------- | ------------- | ----------- | ---------------------------- | -------------- |
| `orientation` | `orientation` |             | `"horizontal" \| "vertical"` | `"horizontal"` |

----------------------------------------------

*Built with [StencilJS](https://stenciljs.com/)*

